### PR TITLE
Least privilege to prometheus out-bucket

### DIFF
--- a/terraform/modules/prometheus/prometheus.tf
+++ b/terraform/modules/prometheus/prometheus.tf
@@ -280,7 +280,10 @@ resource "aws_iam_role_policy" "costbuddy_instance_policy" {
                 "s3:Get*",
                 "s3:List*"
             ],
-            "Resource": "*"
+            "Resource": [
+              "arn:aws:s3:::${aws_s3_bucket.out_bucket[0].id}",
+              "arn:aws:s3:::${aws_s3_bucket.out_bucket[0].id}/*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This PR reduces the IAM policy to only allow S3 bucket permissions to necessary resources 